### PR TITLE
Add CI workflow to check if it compiles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,13 +26,14 @@ jobs:
           mkdir ./extlib/openmm/build/
           mkdir ${GITHUB_WORKSPACE}/extlib/openmm-8/
     - name: Build and Install OpenMM
-      working-directory: ./extlib/openmm/build
       if: steps.cache-openmm-restore.outputs.cache-hit != 'true'
+      working-directory: ./extlib/openmm/build
       run: |
           cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/extlib/openmm-8/
           make
           make install
     - name: Save OpenMM Library
+      if: steps.cache-openmm-restore.outputs.cache-hit != 'true'
       id: cache-openmm-save
       uses: actions/cache/save@v3
       with:


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to check if the code compiles.

This workflow downloads and compiles OpenMM v8.0.0 at the first time (it takes ~15 min). The next time it runs, the cached libraries are re-used, so the execution time is reduced.

It does not check if the built binary runs because it requires CUDA. We need to add CPU support to check it because none of the CI services provides free GPU environment (AFAIK).