### PR TITLE
feat: use stod to convert string to double

### DIFF
--- a/src/input/ReadGenesisForceFieldGenerator.hpp
+++ b/src/input/ReadGenesisForceFieldGenerator.hpp
@@ -22,8 +22,8 @@ read_genesis_harmonic_bond_ff_generator(
         {
             const std::size_t idx_i = std::stoi(bonds_line.substr( 0, 10)) - 1;
             const std::size_t idx_j = std::stoi(bonds_line.substr(10, 10)) - 1;
-            const double      v0    = std::stof(bonds_line.substr(25, 42));
-            const double      k     = std::stof(bonds_line.substr(43, 60)) * 0.5; // KJ/(mol nm^2)
+            const double      v0    = std::stod(bonds_line.substr(25, 42));
+            const double      k     = std::stod(bonds_line.substr(43, 60)) * 0.5; // KJ/(mol nm^2)
             indices_vec.push_back(std::make_pair(idx_i, idx_j));
             v0s        .push_back(v0);
             ks         .push_back(k);
@@ -50,9 +50,9 @@ read_genesis_gaussian_bond_ff_generator(
         {
             const std::size_t idx_i = std::stoi(angles_line.substr(0,  10)) - 1;
             const std::size_t idx_k = std::stoi(angles_line.substr(20, 10)) - 1;
-            const double      v0    = std::stof(angles_line.substr(35, 15)); // nm
-            const double      k     = -std::stof(angles_line.substr(50, 15)); // KJ/mol
-            const double      sigma = std::stof(angles_line.substr(65, 15)); // nm
+            const double      v0    = std::stod(angles_line.substr(35, 15)); // nm
+            const double      k     = -std::stod(angles_line.substr(50, 15)); // KJ/mol
+            const double      sigma = std::stod(angles_line.substr(65, 15)); // nm
 
             indices_vec.push_back(std::make_pair(idx_i, idx_k));
             v0s        .push_back(v0);
@@ -77,8 +77,8 @@ read_genesis_go_contact_ff_generator(
     {
         const std::size_t idx_i = std::stoi(pairs_line.substr(0,  10)) - 1;
         const std::size_t idx_k = std::stoi(pairs_line.substr(10, 10)) - 1;
-        const double      r0    = std::stof(pairs_line.substr(30, 15)); // nm
-        const double      k     = std::stof(pairs_line.substr(45, 15)); // KJ/mol
+        const double      r0    = std::stod(pairs_line.substr(30, 15)); // nm
+        const double      k     = std::stod(pairs_line.substr(45, 15)); // KJ/mol
 
         indices_vec.push_back(std::make_pair(idx_i, idx_k));
         ks         .push_back(k);
@@ -143,9 +143,9 @@ read_genesis_gaussian_dihedral_ff_generator(
             const std::size_t  idx_j  = std::stoi(dihedrals_line.substr(10, 10)) - 1;
             const std::size_t  idx_k  = std::stoi(dihedrals_line.substr(20, 10)) - 1;
             const std::size_t  idx_l  = std::stoi(dihedrals_line.substr(30, 10)) - 1;
-            const double       theta0 = std::stof(dihedrals_line.substr(45, 15)) / 180.0 * Constant::pi; // radiuns
-            const double       k      = -std::stof(dihedrals_line.substr(60, 15)); // KJ/mol
-            const double       sigma  = std::stof(dihedrals_line.substr(75, 15)); // radiuns
+            const double       theta0 = std::stod(dihedrals_line.substr(45, 15)) / 180.0 * Constant::pi; // radiuns
+            const double       k      = -std::stod(dihedrals_line.substr(60, 15)); // KJ/mol
+            const double       sigma  = std::stod(dihedrals_line.substr(75, 15)); // radiuns
 
             indices_vec.push_back({idx_i, idx_j, idx_k, idx_l});
             ks         .push_back(k);
@@ -243,7 +243,7 @@ read_genesis_exv_ff_generator(const std::vector<std::string>& atomtypes_data,
         const std::string name = Utility::erase_space(atomtypes_line.substr(0, 5));
         if(name_rmin_map.find(name) == name_rmin_map.end())
         {
-            const double rmin = std::stof(atomtypes_line.substr(30, 10)) * 0.5;
+            const double rmin = std::stod(atomtypes_line.substr(30, 10)) * 0.5;
             name_rmin_map.insert(std::make_pair(name, rmin));
         }
         else
@@ -261,7 +261,7 @@ read_genesis_exv_ff_generator(const std::vector<std::string>& atomtypes_data,
             throw std::runtime_error("[error] ExcludedVolumeForceField only support uniform eps for all particle case. Some different value were defined in `[ atomtypes ]` table.");
         }
     }
-    const double eps = std::stof(eps_str);
+    const double eps = std::stod(eps_str);
 
     std::vector<std::optional<double>> radius_vec;
     for(auto& atoms_line : atoms_data)

--- a/src/input/ReadGenesisInput.hpp
+++ b/src/input/ReadGenesisInput.hpp
@@ -169,9 +169,9 @@ std::vector<OpenMM::Vec3> read_genesis_initial_conf(
     for(std::size_t idx=0; idx<system_size; ++idx)
     {
         std::getline(ifs, line);
-        initPosInNm[idx] = OpenMM::Vec3(std::stof(line.substr(20, 9)),
-                                        std::stof(line.substr(29, 9)),
-                                        std::stof(line.substr(38, 9))); // location, nm
+        initPosInNm[idx] = OpenMM::Vec3(std::stod(line.substr(20, 9)),
+                                        std::stod(line.substr(29, 9)),
+                                        std::stod(line.substr(38, 9))); // location, nm
     }
 
     return initPosInNm;
@@ -195,7 +195,7 @@ Simulator make_simulator_from_genesis_inputs(
     std::vector<std::string> res_name_vec, atom_name_vec;
     for(auto& atoms_line : top_data.at("atoms"))
     {
-        mass_vec.push_back(std::stof(atoms_line.substr(49, 9))); // amu
+        mass_vec.push_back(std::stod(atoms_line.substr(49, 9))); // amu
         res_name_vec .push_back(atoms_line.substr(27, 3));
         atom_name_vec.push_back(atoms_line.substr(31, 4));
     }
@@ -359,7 +359,7 @@ Simulator make_simulator_from_genesis_inputs(
     // read [DYNAMICS] section
     const std::map<std::string, std::string> dynamics_section = inpfile_data.at("DYNAMICS");
     const std::size_t nsteps        = std::stoi(dynamics_section.at("nsteps"));
-    const double      timestep      = std::stof(dynamics_section.at("timestep")); // ps
+    const double      timestep      = std::stod(dynamics_section.at("timestep")); // ps
     const std::size_t crdout_period = std::stoi(dynamics_section.at("crdout_period"));
     std::size_t seed = 0;
     if(dynamics_section.find("iseed") != dynamics_section.end())
@@ -369,8 +369,8 @@ Simulator make_simulator_from_genesis_inputs(
 
     // read [EMSEMBLE] section
     const std::map<std::string, std::string> emsemble_section = inpfile_data.at("ENSEMBLE");
-    const double temperature = std::stof(emsemble_section.at("temperature"));
-    const double gamma_t     = std::stof(emsemble_section.at("gamma_t")); // GENESIS gamma_t unit is ps^-1
+    const double temperature = std::stod(emsemble_section.at("temperature"));
+    const double gamma_t     = std::stod(emsemble_section.at("gamma_t")); // GENESIS gamma_t unit is ps^-1
 
     // setup OpenMM integrator
     // In OpenMM, we cannot use different friction coefficiet, gamma, for


### PR DESCRIPTION
`std::stof` converts a `std::string` to a `float`.
However, everywhere this function is called, the return value is implicitly converted to a `double`.
For this purpose, `std::stod` function, which converts a `std::string` to a `double`, should be used.

cf.
* https://cpprefjp.github.io/reference/string/stof.html
* https://cpprefjp.github.io/reference/string/stod.html