### PR TITLE
fix: if output path is empty, set it pwd.

### DIFF
--- a/src/input/ReadTOMLInput.hpp
+++ b/src/input/ReadTOMLInput.hpp
@@ -518,6 +518,10 @@ Simulator read_toml_input(const std::string& toml_file_name)
     const bool         dump_progress_bar =
         toml::find_or<bool>(output, "progress_bar", true);
     std::string output_path   = toml::find<std::string>(output, "path");
+    if(output_path.empty())
+    {
+        output_path = "./";
+    }
     if(output_path.back() != '/')
     {
         output_path += '/';


### PR DESCRIPTION
Currently, because of #15, an empty `files.output.path` becomes root path.
Normally people do not use root as output dir. It is better to interpret an empty path as pwd.