### PR TITLE
feat: make optional platform_table an empty table

### DIFF
--- a/src/input/ReadTOMLInput.hpp
+++ b/src/input/ReadTOMLInput.hpp
@@ -768,7 +768,7 @@ Simulator read_toml_input(const std::string& toml_file_name)
     observers.push_back(std::make_unique<EnergyObserver>(output_path+output_prefix, system_gen));
 
     // read platform
-    const auto platform_table = toml::find_or(data, "platform", {});
+    const auto platform_table = toml::find_or(data, "platform", toml::value(toml::table{}));
     const auto platform_name  = toml::find_or<std::string>(platform_table, "name", std::string("CUDA"));
     std::cerr << "    OpenMM platform : " << platform_name << std::endl;
 


### PR DESCRIPTION
if it is an empty value, `toml::value::contains` fails and the error message becomes difficult to understand.