### PR TITLE
fix: add ignore_group_pairs setting to 3spn2 excluded volume

### DIFF
--- a/src/forcefield/ThreeSPN2ExcludedVolumeForceFieldGenerator.hpp
+++ b/src/forcefield/ThreeSPN2ExcludedVolumeForceFieldGenerator.hpp
@@ -20,11 +20,100 @@ class ThreeSPN2ExcludedVolumeForceFieldGenerator final : public ForceFieldGenera
   public:
     ThreeSPN2ExcludedVolumeForceFieldGenerator(const double eps, const double cutoff,
         const std::vector<std::optional<double>>& radiuses,
-        const index_pairs_type& ignore_list, const bool use_periodic)
+        const index_pairs_type& ignore_list, const bool use_periodic,
+        const std::vector<std::pair<std::string, std::string>> ignore_group_pairs = {},
+        const std::vector<std::optional<std::string>> group_vec = {})
         : eps_(eps), cutoff_(cutoff), radiuses_(radiuses), ignore_list_(ignore_list),
-          use_periodic_(use_periodic),
-          ffgen_id_(fmt::format("TSPN2_EXV{}", ffid.gen()))
-    {}
+          use_periodic_(use_periodic), ffgen_id_(fmt::format("TSPN2_EXV{}", ffid.gen()))
+    {
+        if(ignore_group_pairs.size() == 0)
+        {
+            // without interaction group force calculation is faster than
+            // with that. So if all particle have the parameter for this
+            // calculation, force don't use interaction group
+            if(std::any_of(radiuses_.begin(), radiuses_.end(),
+                          [](const std::optional<double>& val) { return !val; }))
+            {
+                std::set<int> participants;
+                for(std::size_t idx=0; idx<radiuses_.size(); ++idx)
+                {
+                    if(radiuses_[idx])
+                    {
+                        participants.insert(idx);
+                    }
+                }
+                interaction_groups_.push_back({ participants, participants });
+            }
+            else
+            {
+                std::cerr << "        all particles are participants in this interaction" << std::endl;
+            }
+        }
+        else // make interaction group when group based ignoration specified
+        {
+            std::set<std::string> related_group_names;
+            for(const auto& name_group_pair : ignore_group_pairs)
+            {
+                related_group_names.insert(name_group_pair.first);
+                related_group_names.insert(name_group_pair.second);
+            }
+
+            std::map<std::string, std::set<int>> related_group_map;
+            for(const auto& name : related_group_names)
+            {
+                related_group_map.insert(std::make_pair(name, std::set<int>()));
+            }
+
+            std::set<int> others;
+            for(std::size_t idx=0; idx<radiuses_.size(); ++idx)
+            {
+                if(radiuses_[idx])
+                {
+                    if(group_vec[idx])
+                    {
+                        const std::string group_name = group_vec[idx].value();
+                        if(related_group_names.count(group_name) != 0)
+                        {
+                            related_group_map.at(group_name).insert(idx);
+                        }
+                        else
+                        {
+                            others.insert(idx);
+                        }
+                    }
+                    else
+                    {
+                        others.insert(idx);
+                    }
+                }
+            }
+
+            std::vector<std::pair<std::string, std::set<int>>> related_group_vec;
+            for(const auto& name_group_pair : related_group_map)
+            {
+                related_group_vec.push_back(name_group_pair);
+            }
+
+            interaction_groups_.push_back({ others, others });
+            for(std::size_t idx_i=0 ; idx_i<related_group_vec.size(); ++idx_i)
+            {
+                const auto& name_group_pair_i = related_group_vec[idx_i];
+                const std::string&   first_name  = name_group_pair_i.first;
+                const std::set<int>& first_group = name_group_pair_i.second;
+                interaction_groups_.push_back({ first_group, others });
+                for(std::size_t idx_j=idx_i; idx_j<related_group_vec.size(); ++idx_j)
+                {
+                    const auto& name_group_pair_j = related_group_vec[idx_j];
+                    const std::string&   second_name  = name_group_pair_j.first;
+                    if(!Utility::contains(ignore_group_pairs, { first_name, second_name }))
+                    {
+                        const std::set<int>& second_group = name_group_pair_j.second;
+                        interaction_groups_.push_back({ first_group, second_group });
+                    }
+                }
+            }
+        }
+    }
 
     std::unique_ptr<OpenMM::Force> generate() const noexcept override
     {

--- a/src/input/ReadTOMLForceFieldGenerator.hpp
+++ b/src/input/ReadTOMLForceFieldGenerator.hpp
@@ -981,7 +981,8 @@ read_toml_excluded_volume_ff_generator(
 
 const ThreeSPN2ExcludedVolumeForceFieldGenerator
 read_toml_3spn2_excluded_volume_ff_generator(
-    const toml::value& global_ff_data, const std::size_t system_size, const Topology& topology,
+    const toml::value& global_ff_data, const std::size_t system_size,
+    const Topology& topology, const std::vector<std::optional<std::string>>& group_vec,
     const bool use_periodic)
 {
     check_keys_available(global_ff_data,
@@ -1064,7 +1065,8 @@ read_toml_3spn2_excluded_volume_ff_generator(
     ignore_list.erase(std::unique(ignore_list.begin(), ignore_list.end()), ignore_list.end());
 
     return ThreeSPN2ExcludedVolumeForceFieldGenerator(
-            eps, cutoff, radius_vec, ignore_list, use_periodic);
+            eps, cutoff, radius_vec, ignore_list, use_periodic,
+            ignore_group_pairs, group_vec);
 }
 
 // WCA input is like below

--- a/src/input/ReadTOMLInput.hpp
+++ b/src/input/ReadTOMLInput.hpp
@@ -420,7 +420,7 @@ SystemGenerator read_toml_system(const toml::value& data)
             {
                 ThreeSPN2ExcludedVolumeForceFieldGenerator ff_gen =
                     read_toml_3spn2_excluded_volume_ff_generator(
-                        global_ff, system_size, topology, use_periodic);
+                        global_ff, system_size, topology, group_vec, use_periodic);
                 system_gen.add_ff_generator(
                         std::make_unique<ThreeSPN2ExcludedVolumeForceFieldGenerator>(ff_gen));
             }


### PR DESCRIPTION
In this PR, we introduce the ignore_group_pair setting to the 3SPN2ExcludedVolumeForceFieldGenerator. This setting allows for the explicit exclusion of interactions between specified groups for calculations of the 3SPN2 excluded volume. This fix is useful when certain intermolecular interactions need to be omitted intentionally.

With this update, the constructor excludes particles with undefined radii from interaction groups. This allows particles with particle types not assumed in the 3SPN2 model to be removed from the 3SPN2 exclusion volume interaction.